### PR TITLE
Replace egirna with integrationworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # icap-client
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Project status](https://img.shields.io/badge/version-0.1.0-green.svg)](https://github.com/egirna/icap-client/releases)
-[![GoDoc](https://godoc.org/github.com/egirna/icap-client?status.svg)](https://godoc.org/github.com/egirna/icap-client)
+<!-- [![Project status](https://img.shields.io/badge/version-0.1.0-green.svg)](https://github.com/egirna/icap-client/releases) -->
+<!-- [![GoDoc](https://godoc.org/github.com/egirna/icap-client?status.svg)](https://godoc.org/github.com/egirna/icap-client) -->
 
 
 Talk to the ICAP servers using probably the first ICAP client package in GO!
@@ -83,7 +83,7 @@ By default the icap-client will dump the debugging logs to the standard output(s
   ic.SetDebugOutput(f)
 ```
 
-For more details, see the [docs](https://godoc.org/github.com/egirna/icap-client) and [examples](examples/).
+<!-- For more details, see the [docs](https://godoc.org/github.com/egirna/icap-client) and [examples](examples/). -->
 
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Talk to the ICAP servers using probably the first ICAP client package in GO!
 
 ### Installing
 ```console
-go get -u github.com/egirna/icap-client
+go get -u github.com/integrationworks/icap-client
 
 ```
 
@@ -18,7 +18,7 @@ go get -u github.com/egirna/icap-client
 **Import The Package**
 
 ```go
-import ic "github.com/egirna/icap-client"
+import ic "github.com/integrationworks/icap-client"
 
 ```
 

--- a/examples/custom_driver.go
+++ b/examples/custom_driver.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	ic "github.com/egirna/icap-client"
+	ic "github.com/integrationworks/icap-client"
 )
 
 func makeRespmodWithCustomDriver() {

--- a/examples/debug.go
+++ b/examples/debug.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	ic "github.com/egirna/icap-client"
+	ic "github.com/integrationworks/icap-client"
 )
 
 func reqmodInDebug() {

--- a/examples/reqmod.go
+++ b/examples/reqmod.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	ic "github.com/egirna/icap-client"
+	ic "github.com/integrationworks/icap-client"
 )
 
 func makeReqmodCall() {

--- a/examples/respmod.go
+++ b/examples/respmod.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	ic "github.com/egirna/icap-client"
+	ic "github.com/integrationworks/icap-client"
 )
 
 func makeRespmodCall() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/egirna/icap-client
+module github.com/integrationworks/icap-client
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,9 @@ module github.com/integrationworks/icap-client
 
 go 1.12
 
+// replace github.com/egirna/icap-client v0.1.1 => github.com/integrationworks/icap-client v0.1.2
+
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/egirna/icap v0.0.0-20181108071049-d5ee18bd70bc
+	github.com/egirna/icap v0.2.0
 )


### PR DESCRIPTION
This change successfully prevents go mod tidy from importing the egirna/icap-client and instead uses the integrationworks/icap-client module. Also imports the egirna/icap v0.2.0. 