### PR TITLE
Altered 204 message to not reason-phrase and only look at status code

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -34,7 +34,7 @@ const (
 	bodyEndIndicator                = CRLF + "0" + CRLF
 	fullBodyEndIndicatorPreviewMode = "; ieof" + DoubleCRLF
 	icap100ContinueMsg              = "ICAP/1.0 100 Continue" + DoubleCRLF
-	icap204NoModsMsg                = "ICAP/1.0 204 No modifications"
+	icap204NoModsMsg                = "ICAP/1.0 204 "
 	defaultChunkLength              = 512
 	defaultTimeout                  = 15 * time.Second
 )


### PR DESCRIPTION
Hey team,

Good client, thank you. Just having trouble with the 204 messages.

The reason for the change:
        1. our av scanner returns a different Reason-Phrase so fails with the old code
	2. The actual Reason-Phrase is not part of the spec so shouldn't be part of the implementation.
